### PR TITLE
Add WPF License Generator with help screens

### DIFF
--- a/HelpWindow.xaml
+++ b/HelpWindow.xaml
@@ -1,0 +1,16 @@
+<Window x:Class="StandardLicensingGenerator.HelpWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Help" Height="400" Width="600">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="10">
+            <TextBlock Text="Standard Licensing Generator Help" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
+            <TextBlock TextWrapping="Wrap">
+This tool creates licenses compatible with the Standard.Licensing library. Fill in the fields for your application, choose your private key and click Generate License.
+            </TextBlock>
+            <TextBlock TextWrapping="Wrap" Margin="0,10,0,0">
+The generated license can be saved to a file using the File menu. Distribute the public key with your application to validate the license.
+            </TextBlock>
+        </StackPanel>
+    </ScrollViewer>
+</Window>

--- a/HelpWindow.xaml.cs
+++ b/HelpWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace StandardLicensingGenerator;
+
+public partial class HelpWindow : Window
+{
+    public HelpWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,12 +1,74 @@
-﻿<Window x:Class="StandardLicensingGenerator.MainWindow"
+<Window x:Class="StandardLicensingGenerator.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:StandardLicensingGenerator"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
-    <Grid>
+        Title="Standard Licensing Generator" Height="550" Width="800">
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="File">
+                <MenuItem Header="Save License" Click="SaveLicense_Click" />
+                <Separator />
+                <MenuItem Header="Exit" Click="Exit_Click" />
+            </MenuItem>
+            <MenuItem Header="Help" Click="ShowHelp_Click" />
+        </Menu>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="License Details" FontSize="18" FontWeight="Bold" Margin="0,0,0,10" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="150" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-    </Grid>
+                    <TextBlock Text="Product Name:" Grid.Row="0" Grid.Column="0" Margin="0,2"/>
+                    <TextBox x:Name="ProductNameBox" Grid.Row="0" Grid.Column="1" Margin="0,2"/>
+
+                    <TextBlock Text="Version:" Grid.Row="1" Grid.Column="0" Margin="0,2"/>
+                    <TextBox x:Name="VersionBox" Grid.Row="1" Grid.Column="1" Margin="0,2"/>
+
+                    <TextBlock Text="License Type:" Grid.Row="2" Grid.Column="0" Margin="0,2"/>
+                    <ComboBox x:Name="LicenseTypeBox" Grid.Row="2" Grid.Column="1" Margin="0,2">
+                        <ComboBoxItem Content="Standard"/>
+                        <ComboBoxItem Content="Trial"/>
+                        <ComboBoxItem Content="Custom"/>
+                    </ComboBox>
+
+                    <TextBlock Text="Expiration Date:" Grid.Row="3" Grid.Column="0" Margin="0,2"/>
+                    <DatePicker x:Name="ExpirationPicker" Grid.Row="3" Grid.Column="1" Margin="0,2"/>
+
+                    <TextBlock Text="Customer Name:" Grid.Row="4" Grid.Column="0" Margin="0,2"/>
+                    <TextBox x:Name="CustomerNameBox" Grid.Row="4" Grid.Column="1" Margin="0,2"/>
+
+                    <TextBlock Text="Customer Email:" Grid.Row="5" Grid.Column="0" Margin="0,2"/>
+                    <TextBox x:Name="CustomerEmailBox" Grid.Row="5" Grid.Column="1" Margin="0,2"/>
+
+                    <TextBlock Text="Additional Attributes (json):" Grid.Row="6" Grid.Column="0" Margin="0,2"/>
+                    <TextBox x:Name="AttributesBox" Grid.Row="6" Grid.Column="1" Margin="0,2" Height="60" TextWrapping="Wrap" AcceptsReturn="True"/>
+
+                    <TextBlock Text="Private Key File:" Grid.Row="7" Grid.Column="0" Margin="0,2"/>
+                    <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Horizontal" Margin="0,2">
+                        <TextBox x:Name="KeyFileBox" Width="300" Margin="0,0,5,0"/>
+                        <Button Content="Browse" Click="BrowseKey_Click" />
+                    </StackPanel>
+                </Grid>
+
+                <Button Content="Generate License" Margin="0,10,0,0" Width="150" HorizontalAlignment="Left" Click="GenerateLicense_Click" />
+                <TextBox x:Name="ResultBox" Margin="0,10,0,0" Height="150" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,23 +1,114 @@
-﻿using System.Text;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using Microsoft.Win32;
+using Standard.Licensing;
+using Standard.Licensing.Security.Cryptography;
 
 namespace StandardLicensingGenerator;
 
-/// <summary>
-/// Interaction logic for MainWindow.xaml
-/// </summary>
 public partial class MainWindow : Window
 {
     public MainWindow()
     {
         InitializeComponent();
+        LicenseTypeBox.SelectedIndex = 0;
+    }
+
+    private void BrowseKey_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new OpenFileDialog
+        {
+            Filter = "XML Key Files (*.xml)|*.xml|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() == true)
+        {
+            KeyFileBox.Text = dlg.FileName;
+        }
+    }
+
+    private void GenerateLicense_Click(object sender, RoutedEventArgs e)
+    {
+        if (!File.Exists(KeyFileBox.Text))
+        {
+            MessageBox.Show("Select a valid private key file.");
+            return;
+        }
+
+        var attributes = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(AttributesBox.Text))
+        {
+            try
+            {
+                var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(AttributesBox.Text);
+                if (parsed != null)
+                {
+                    foreach (var kvp in parsed)
+                        attributes[kvp.Key] = kvp.Value;
+                }
+            }
+            catch
+            {
+                MessageBox.Show("Invalid JSON in additional attributes.");
+                return;
+            }
+        }
+
+        var builder = License.New()
+            .WithUniqueIdentifier(Guid.NewGuid())
+            .LicensedTo(CustomerNameBox.Text, CustomerEmailBox.Text)
+            .WithType(ParseLicenseType())
+            .ExpiresAt(ExpirationPicker.SelectedDate ?? DateTime.MaxValue)
+            .WithProductFeatures(f =>
+            {
+                f.Add("Product", ProductNameBox.Text);
+                f.Add("Version", VersionBox.Text);
+            })
+            .WithAdditionalAttributes(a =>
+            {
+                foreach (var kvp in attributes)
+                    a.Add(kvp.Key, kvp.Value);
+            });
+
+        var privateKey = File.ReadAllText(KeyFileBox.Text);
+        var license = builder.CreateAndSignWithPrivateKey(privateKey, null);
+        ResultBox.Text = license.ToString();
+    }
+
+    private LicenseType ParseLicenseType()
+    {
+        if (LicenseTypeBox.SelectedItem is ComboBoxItem item)
+        {
+            var text = item.Content?.ToString();
+            if (Enum.TryParse<LicenseType>(text, out var type))
+                return type;
+        }
+        return LicenseType.Standard;
+    }
+
+    private void SaveLicense_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new SaveFileDialog
+        {
+            Filter = "License File (*.lic)|*.lic|All files (*.*)|*.*"
+        };
+        if (dlg.ShowDialog() == true)
+        {
+            File.WriteAllText(dlg.FileName, ResultBox.Text);
+        }
+    }
+
+    private void Exit_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void ShowHelp_Click(object sender, RoutedEventArgs e)
+    {
+        var help = new HelpWindow();
+        help.Owner = this;
+        help.ShowDialog();
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # StandardLicensingGenerator
 
+A Windows desktop tool for generating licenses compatible with the [Standard.Licensing](https://github.com/dnauck/Standard.Licensing) library. The application lets you configure all available license options, sign them with your private key and save the result for distribution.
+
+## Features
+
+- Create **Standard**, **Trial** and **Custom** license types
+- Set product name, version and expiration date
+- Store customer information (name and email)
+- Add any additional attributes using JSON
+- Sign licenses using your own RSA private key
+- Save generated licenses to a file
+- Built-in help screen describing how to use the tool
+
+The UI is designed with sensible defaults and labeled inputs so generating a license only requires filling in the desired fields and selecting your private key.
+
+## Usage
+
+1. Start the application.
+2. Enter your product details and customer information.
+3. Select the desired license type and expiration date.
+4. Optionally add extra attributes in JSON format (e.g. `{ "Seats": "5" }`).
+5. Browse to your private key file (XML RSA key used to sign licenses).
+6. Click **Generate License** to view the resulting license text.
+7. Use **File → Save License** to store the license in a `.lic` file.
+
+The generated license can then be validated in your application using the matching public key with the Standard.Licensing library.
+
+## Distribution
+
+The project targets `net9.0-windows` and can be published as a single-file executable for easy distribution (e.g. via web download). Run `dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true` to produce a distributable package.
+
+## Help
+
+A detailed help window is available from the **Help** menu inside the application. It provides a short overview of the workflow and explains where to place your private/public keys.
+


### PR DESCRIPTION
## Summary
- build out UI for generating licenses
- add logic to create licenses with Standard.Licensing
- include a help window
- document usage in README

## Testing
- `dotnet build StandardLicensingGenerator.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474e36b694832182d61c2efee95c43