### PR TITLE
Add JSON window settings persistence utility

### DIFF
--- a/UiSettings/WindowSettings.cs
+++ b/UiSettings/WindowSettings.cs
@@ -1,0 +1,34 @@
+using System.Windows;
+
+namespace StandardLicensingGenerator.UiSettings;
+
+public class WindowSettings
+{
+    public double Top { get; set; }
+    public double Left { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+    public WindowState WindowState { get; set; }
+
+    public static WindowSettings FromWindow(Window window)
+    {
+        return new WindowSettings
+        {
+            Top = window.Top,
+            Left = window.Left,
+            Width = window.Width,
+            Height = window.Height,
+            WindowState = window.WindowState
+        };
+    }
+
+    public void ApplyTo(Window window)
+    {
+        window.Top = Top;
+        window.Left = Left;
+        window.Width = Width;
+        window.Height = Height;
+        window.WindowState = WindowState;
+    }
+}
+

--- a/UiSettings/WindowSettingsManager.cs
+++ b/UiSettings/WindowSettingsManager.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Windows;
+
+namespace StandardLicensingGenerator.UiSettings;
+
+public class WindowSettingsManager
+{
+    private readonly Window _window;
+    private readonly string _filePath;
+
+    public WindowSettingsManager(Window window, string? fileName = null)
+    {
+        _window = window ?? throw new ArgumentNullException(nameof(window));
+
+        string appName = Assembly.GetEntryAssembly()?.GetName().Name ?? "Application";
+        string folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName);
+        Directory.CreateDirectory(folder);
+
+        string name = fileName ?? $"{_window.GetType().Name}.json";
+        _filePath = Path.Combine(folder, name);
+    }
+
+    public void Load()
+    {
+        if (!File.Exists(_filePath))
+            return;
+        try
+        {
+            string json = File.ReadAllText(_filePath);
+            var settings = JsonSerializer.Deserialize<WindowSettings>(json);
+            settings?.ApplyTo(_window);
+        }
+        catch
+        {
+            // ignore invalid files
+        }
+    }
+
+    public void Save()
+    {
+        var settings = WindowSettings.FromWindow(_window);
+        var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(_filePath, json);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `WindowSettings` record to store common window properties
- add `WindowSettingsManager` to load/save settings from `%APPDATA%/<AppName>`
- create `UiSettings` folder for the new classes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684866bde0608321b6d947b173b45c85