### PR TITLE
Handle RSA private key headers

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -190,6 +190,8 @@ public partial class MainWindow
                 return;
             }
 
+            privateKeyPemString = KeyFormatUtility.NormalizePrivateKey(privateKeyPemString);
+
             var license = builder.CreateAndSignWithPrivateKey(privateKeyPemString, "");
             ResultBox.Text = license.ToString();
         }


### PR DESCRIPTION
## Summary
- support `BEGIN RSA PRIVATE KEY` blocks
- normalize the key before signing

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489b3f79048321ab6da0a74af22de3