### PR TITLE
Handle encrypted keys

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -193,8 +193,20 @@ public partial class MainWindow
             privateKeyPemString = KeyFormatUtility.NormalizePrivateKey(privateKeyPemString);
             var base64Key = KeyFormatUtility.GetBase64Key(privateKeyPemString);
 
-            var license = builder.CreateAndSignWithPrivateKey(base64Key, "");
+            var license = builder.CreateAndSignWithPrivateKey(base64Key, null);
             ResultBox.Text = license.ToString();
+        }
+        catch (ArgumentException argEx) when (argEx.Message.Contains("Bad sequence size"))
+        {
+            MessageBox.Show(
+                "The selected private key appears to be encrypted with a passphrase. " +
+                "This tool currently supports only unencrypted keys.",
+                "Unsupported Key",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+
+            string detailedInfo = GetDetailedExceptionInfo(argEx);
+            ResultBox.Text = $"Error Details:\n{detailedInfo}";
         }
         catch (Exception ex)
         {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The UI is designed with sensible defaults and labeled inputs so generating a lic
 3. Select the desired license type and expiration date.
 4. Optionally add extra attributes in JSON format (e.g. `{ "Seats": "5" }`).
 5. Browse to your private key file. PEM keys are recommended, but existing XML keys are also supported.
+   Keys must be unencrypted; passphrase-protected keys are not currently supported.
 6. Click **Generate License** to view the resulting license text.
 7. Use **File → Save License** to store the license in a `.lic` file.
 


### PR DESCRIPTION
## Summary
- handle attempt to use an encrypted private key
- mention that encrypted keys are unsupported in the README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489de39c1c8321ae2af90ec26f654a