### PR TITLE
Fix: Improve private key parsing for license generation

### DIFF
--- a/KeyFormatUtility.cs
+++ b/KeyFormatUtility.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
@@ -105,26 +106,119 @@ public static class KeyFormatUtility
         const string rsaHeader = "-----BEGIN RSA PRIVATE KEY-----";
         const string rsaFooter = "-----END RSA PRIVATE KEY-----";
 
-        string CleanSection(string input, string header, string footer)
+        string? extractedBody = null;
+        string trimmedPemKey = pemKey.Trim(); // Trim upfront
+
+        // Normalize line endings in the input PEM key to handle mixed environments
+        string normalizedPemKey = trimmedPemKey.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        if (normalizedPemKey.Contains(pkcs8Header) && normalizedPemKey.Contains(pkcs8Footer))
         {
-            int start = input.IndexOf(header, StringComparison.Ordinal);
-            if (start < 0) return input;
-
-            start += header.Length;
-            int end = input.IndexOf(footer, start, StringComparison.Ordinal);
-            if (end < 0) return input;
-
-            string body = input.Substring(start, end - start);
-            return body.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
+            int startIdx = normalizedPemKey.IndexOf(pkcs8Header, StringComparison.Ordinal);
+            if (startIdx != -1) {
+                startIdx += pkcs8Header.Length;
+                int endIdx = normalizedPemKey.IndexOf(pkcs8Footer, startIdx, StringComparison.Ordinal);
+                if (endIdx != -1)
+                {
+                    extractedBody = normalizedPemKey.Substring(startIdx, endIdx - startIdx);
+                }
+            }
+        }
+        else if (normalizedPemKey.Contains(rsaHeader) && normalizedPemKey.Contains(rsaFooter))
+        {
+            int startIdx = normalizedPemKey.IndexOf(rsaHeader, StringComparison.Ordinal);
+            if (startIdx != -1)
+            {
+                startIdx += rsaHeader.Length;
+                int endIdx = normalizedPemKey.IndexOf(rsaFooter, startIdx, StringComparison.Ordinal);
+                if (endIdx != -1)
+                {
+                    extractedBody = normalizedPemKey.Substring(startIdx, endIdx - startIdx);
+                }
+            }
         }
 
-        if (pemKey.Contains(pkcs8Header))
-            return CleanSection(pemKey, pkcs8Header, pkcs8Footer);
+        if (extractedBody != null)
+        {
+            // Remove all whitespace including newlines from the extracted Base64 body
+            return System.Text.RegularExpressions.Regex.Replace(extractedBody, @"\s+", "");
+        }
+        else
+        {
+            // Input is not a recognized PEM format with the specified headers.
+            // Check if the input itself might be a bare Base64 string.
+            string cleanedPotentialBase64 = System.Text.RegularExpressions.Regex.Replace(trimmedPemKey, @"\s+", "");
+            if (IsBase64String(cleanedPotentialBase64)) {
+                 return cleanedPotentialBase64;
+            }
+            // Otherwise, it's an unrecognized format or not a key we can directly use.
+            throw new ArgumentException("The provided key is not in a recognized unencrypted PEM format (PKCS#1 or PKCS#8 private key) and does not appear to be a bare Base64 string. Please ensure the key is an unencrypted private key in PEM format or a raw Base64 string.", nameof(pemKey));
+        }
+    }
 
-        if (pemKey.Contains(rsaHeader))
-            return CleanSection(pemKey, rsaHeader, rsaFooter);
+    private static bool IsBase64String(string s)
+    {
+        s = s.Trim();
+        if (s.Length == 0 || s.Length % 4 != 0)
+            return false;
 
-        // Assume already base64
-        return pemKey.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
+        // Check for valid Base64 characters (A-Z, a-z, 0-9, +, /, =)
+        // and that padding characters (=) are only at the end.
+        int paddingCount = 0;
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (char.IsLetterOrDigit(c) || c == '+' || c == '/')
+            {
+                if (paddingCount > 0) return false; // char after padding
+            }
+            else if (c == '=')
+            {
+                paddingCount++;
+            }
+            else
+            {
+                return false; // Invalid character
+            }
+        }
+        // Allow 0, 1, or 2 padding characters.
+        // If there's 1 padding char, the second to last char must also be padding (invalid)
+        // but this is better checked by Convert.TryFromBase64String if available.
+        // For this regex-like check, we just ensure padding is at the end.
+        // A more robust check for complex cases:
+        if (s.EndsWith("===")) return false; // Max two padding chars
+        if (s.EndsWith("==") && s.Length > 1 && s[s.Length-3] == '=') return false; // e.g. "A===" invalid
+
+        // Attempt to convert to prove it's valid base64.
+        // This is the most reliable check if .NET version supports it well.
+        // For older .NET Framework, this might be less performant or have quirks.
+        // Using a simpler regex-like check for characters and padding is often sufficient for filtering.
+        // Let's stick to char validation and padding rules for broader compatibility here,
+        // as Convert.TryFromBase64String might not be available or behave consistently in older .NET Fx.
+
+        // Re-checking padding logic more simply:
+        if (paddingCount > 2) return false;
+        if (paddingCount > 0 && (s[s.Length - 1] != '=' || (paddingCount == 2 && s[s.Length - 2] != '=')))
+        {
+            // This check ensures padding chars are indeed at the end.
+            // Example: "abc=d" would be false. "ab==" is fine. "abc=" is fine.
+        }
+
+
+        // Fallback to a regex for a common check, though the loop above is more precise for padding.
+        // This regex allows for more than 2 padding chars if not careful with its use.
+        // The loop is better.
+        // return System.Text.RegularExpressions.Regex.IsMatch(s, @"^[a-zA-Z0-9\+/]*={0,2}$", System.Text.RegularExpressions.RegexOptions.None);
+        // The loop above is more accurate than a simple regex for padding.
+
+        // Final check for the loop logic:
+        // Ensure all non-padding chars are valid, and padding is only at the end and max 2.
+        for (int i = 0; i < s.Length - paddingCount; i++)
+        {
+            char c = s[i];
+            if (!(char.IsLetterOrDigit(c) || c == '+' || c == '/'))
+                return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
The KeyFormatUtility.GetBase64Key method has been updated to be more strict about the format of input private keys. It now specifically looks for PKCS#1 (-----BEGIN RSA PRIVATE KEY-----) or PKCS#8 (-----BEGIN PRIVATE KEY-----) PEM headers to extract the Base64 encoded key.

If these headers are not found, it attempts to validate if the input is a raw Base64 string. If neither condition is met, it throws a clear ArgumentException, guiding you that the key is not in a recognized unencrypted format.

This change prevents issues where an unsupported key type (e.g., an encrypted PEM file) could lead to cryptic errors like "Bad sequence size" during license signing. The error handling is now more direct and informative.

A helper method IsBase64String has been added to assist in validating potential raw Base64 input.